### PR TITLE
Make test file use python version only if lark is detected

### DIFF
--- a/test-deduce.py
+++ b/test-deduce.py
@@ -101,13 +101,13 @@ if __name__ == "__main__":
             extra_arguments.append(argument)
     
     python_path = ""
-    for i in range(11, 13):
+    for i in range(14, 10, -1):
         python_path = os.popen("command -v python3." + str(i)).read()[0: -1] # strip the newline character with the splicing
-        if python_path != "":
+        if python_path != "" and os.system(python_path + " -m pip list | grep lark > /dev/null") == 0:
             break
     
     if python_path == "":
-        print("Could not find a python version at or above 3.11")
+        print("Could not find a python version at or above 3.11 with lark installed")
         exit(1)
     
     deduce_call = python_path + " ./deduce.py " + " --dir " + lib_dir + " " + " ".join(extra_arguments)


### PR DESCRIPTION
Basically the test file now does a "grep lark" to see if it exists, and if the grep returns 0 then lark is installed. Also, I made the file look for Python versions starting a 3.14 instead of 3.13 as python 3.14 is slated for release this year.

"py test-deduce.py" functions as expected with this change when one has multiple python versions installed.